### PR TITLE
Implement the setjmp.s and longjmp.s on the repo target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,8 @@ distclean: clean
 # YY: build for the repo target.
 #
 EXCLUDED_SRCS = ./crt/x86_64/crti.s \
-		./crt/x86_64/crtn.s \
-		./src/fenv/x86_64/fenv.s \
+                ./crt/x86_64/crtn.s \
+                ./src/fenv/x86_64/fenv.s \
                 ./src/ldso/x86_64/dlsym.s \
                 ./src/ldso/x86_64/tlsdesc.s \
                 ./src/math/x86_64/acosl.s \
@@ -257,8 +257,6 @@ EXCLUDED_SRCS = ./crt/x86_64/crti.s \
                 ./src/math/x86_64/log2l.s \
                 ./src/math/x86_64/logl.s \
                 ./src/process/x86_64/vfork.s \
-                ./src/setjmp/x86_64/longjmp.s \
-                ./src/setjmp/x86_64/setjmp.s \
                 ./src/signal/x86_64/restore.s \
                 ./src/signal/x86_64/sigsetjmp.s \
                 ./src/string/x86_64/memcpy.s \
@@ -268,16 +266,20 @@ EXCLUDED_SRCS = ./crt/x86_64/crti.s \
                 ./src/thread/x86_64/clone.s \
                 ./src/thread/x86_64/syscall_cp.s
 EXCLUDED_ALL = ./crt/Scrt1.c \
-		./crt/rcrt1.c \
-		./ldso/dlstart.c \
-		./src/thread/x86_64/__set_thread_area.s \
-		$(EXCLUDED_SRCS)
+               ./crt/rcrt1.c \
+               ./ldso/dlstart.c \
+               ./src/thread/x86_64/__set_thread_area.s \
+               ./src/setjmp/x86_64/longjmp.s \
+               ./src/setjmp/x86_64/setjmp.s \
+               $(EXCLUDED_SRCS)
 EXCLUDED_TICKETS = $(addprefix obj/, $(patsubst $(srcdir)/%,%.t,$(basename $(EXCLUDED_ALL))))
 REPLACEMENT_GENERIC = $(sort $(subst /$(ARCH)/,/,$(EXCLUDED_SRCS)))
 REPLACEMENT_GENERIC_TICKETS = $(addprefix obj/, $(patsubst $(srcdir)/%,%.t,$(basename $(REPLACEMENT_GENERIC))))
 ALL_TICKETS = $(filter-out $(EXCLUDED_TICKETS), $(sort $(ALL_OBJS:.o=.t) $(REPLACEMENT_GENERIC_TICKETS)))
 
-JSON_TICKET = obj/src/thread/__set_thread_area.t
+JSON_TICKET = obj/src/thread/__set_thread_area.t \
+              obj/src/setjmp/x86_64/longjmp.t \
+              obj/src/setjmp/x86_64/setjmp.t
 JSON_CRT_TICKET = obj/crt/crt1_asm.t
 DB = lib/clang.db
 TEXTUAL_DB = lib/musl-prepo.json
@@ -306,9 +308,17 @@ $(JSON_CRT_TICKET): clang.db
 	mkdir -p obj/crt
 	repo-create-ticket --output=$@ --repo=$< 0d89c794f89f75747df70d0f6b2832ed
 
-$(JSON_TICKET): clang.db
+obj/src/thread/__set_thread_area.t: clang.db
 	mkdir -p obj/src/thread
 	repo-create-ticket --output=$@ --repo=$< 61823da085f534c947264e1497f73741
+
+obj/src/setjmp/x86_64/longjmp.t: clang.db
+	mkdir -p obj/src/setjmp/x86_64
+	repo-create-ticket --output=$@ --repo=$< b4969a1aad5e095bfdb567c8929359a2
+
+obj/src/setjmp/x86_64/setjmp.t: clang.db
+	mkdir -p obj/src/setjmp/x86_64
+	repo-create-ticket --output=$@ --repo=$< 140eae3767a12b28780d48ef2e02a69e
 
 obj/src/internal/version.t: obj/src/internal/version.h
 

--- a/src/musl-prepo.json
+++ b/src/musl-prepo.json
@@ -9,7 +9,9 @@
         "_DYNAMIC",
         "_start",
         "_start_c",
-        "__set_thread_area"
+        "__set_thread_area",
+        "setjmp",
+        "longjmp"
       ],
       "fragments":{
         "1b001e16f7b94e70b0d44714558ea9f5":{
@@ -45,7 +47,55 @@
            // 	   ret
             "data":"SIn+vwIQAAC4ngAAAA8Fww=="
           }
-	}
+        },
+        "d8866e5798e0a50c741e3f1cc110e343":{
+          "text":{
+           // .global __setjmp
+           // .global _setjmp
+           // .global setjmp
+           // .type __setjmp,@function
+           // .type _setjmp,@function
+           // .type setjmp,@function
+           // __setjmp:
+           // _setjmp:
+           // setjmp:
+           // 	mov %rbx,(%rdi)         /* rdi is jmp_buf, move registers onto it */
+           // 	mov %rbp,8(%rdi)
+           // 	mov %r12,16(%rdi)
+           // 	mov %r13,24(%rdi)
+           // 	mov %r14,32(%rdi)
+           // 	mov %r15,40(%rdi)
+           // 	lea 8(%rsp),%rdx        /* this is our rsp WITHOUT current ret addr */
+           // 	mov %rdx,48(%rdi)
+           // 	mov (%rsp),%rdx         /* save return addr ptr for new rip */
+           // 	mov %rdx,56(%rdi)
+           // 	xor %eax,%eax           /* always return 0 */
+           // 	ret
+            "data":"SIkfSIlvCEyJZxBMiW8YTIl3IEyJfyhIjVQkCEiJVzBIixQkSIlXODHAww=="
+          }
+	},
+        "9d160afa2ae306a8827cb8fed42d82cc":{
+          "text":{
+           // .global _longjmp
+           // .global longjmp
+           // .type _longjmp,@function
+           // .type longjmp,@function
+           // _longjmp:
+           // longjmp:
+           // 	xor %eax,%eax
+           // 	cmp $1,%esi             /* CF = val ? 0 : 1 */
+           // 	adc %esi,%eax           /* eax = val + !val */
+           // 	mov (%rdi),%rbx         /* rdi is the jmp_buf, restore regs from it */
+           // 	mov 8(%rdi),%rbp
+           // 	mov 16(%rdi),%r12
+           // 	mov 24(%rdi),%r13
+           // 	mov 32(%rdi),%r14
+           // 	mov 40(%rdi),%r15
+           // 	mov 48(%rdi),%rsp
+           // 	jmp *56(%rdi)           /* goto saved address without altering rsp */
+            "data":"McCD/gER8EiLH0iLbwhMi2cQTItvGEyLdyBMi38oSItnMP9nOA=="
+          }
+        }
       },
       "compilations":{
         "0d89c794f89f75747df70d0f6b2832ed":{
@@ -58,6 +108,18 @@
           "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
             {"digest":"461387b22c520e0c42df3c56ab2aa511","name":4,"linkage":"external","visibility":"hidden"} //"__set_thread_area"
+          ]
+        },
+        "140eae3767a12b28780d48ef2e02a69e":{
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
+          "definitions":[
+            {"digest":"d8866e5798e0a50c741e3f1cc110e343","name":5,"linkage":"external"} //"setjmp"
+          ]
+        },
+        "b4969a1aad5e095bfdb567c8929359a2":{
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
+          "definitions":[
+            {"digest":"9d160afa2ae306a8827cb8fed42d82cc","name":6,"linkage":"external"} //"longjmp"
           ]
         }
       }


### PR DESCRIPTION
When building the clang project using musl-prepo libc and LLVM C++ libraries, I got the undefined reference errors.
```
> Linking CXX executable bin/clang-11
ERROR:wrap_tool:clang: warning: argument unused during compilation: '-nostdinc' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-nostdinc++' [-Wunused-command-line-argument]
/usr/bin/ld: lib/libLLVMSupport.a(CrashRecoveryContext.cpp.o.elf): in function `(anonymous namespace)::CrashRecoveryContextImpl::HandleCrash(int, unsigned long)':
(.text._ZN12_GLOBAL__N_124CrashRecoveryContextImpl11HandleCrashEim+0x98): undefined reference to ` longjmp'
/usr/bin/ld: lib/libLLVMSupport.a(CrashRecoveryContext.cpp.o.elf): in function `llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>)':
(.text._ZN4llvm20CrashRecoveryContext9RunSafelyENS_12function_refIFvvEEE+0xc9): undefined reference to `setjmp'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The `longjmp` and `setjmp` are assembly codes and defined in the musl-libc. We excluded these two assembly files when building musl-libc targeted on repo.

This commit includes the implementation of the setjmp.s and longjmp.s on the repo target.
