### PR TITLE
Remove non-standard alias variables

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -464,6 +464,8 @@ pid_t gettid(void);
 #define _CS_V6_ENV	1148
 #define _CS_V7_ENV	1149
 
+#define __environ environ
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/env/__environ.c
+++ b/src/env/__environ.c
@@ -1,6 +1,3 @@
 #include <unistd.h>
 
-char **__environ = 0;
-weak_alias(__environ, ___environ);
-weak_alias(__environ, _environ);
-weak_alias(__environ, environ);
+char **environ = 0;

--- a/src/internal/libc.c
+++ b/src/internal/libc.c
@@ -3,7 +3,5 @@
 struct __libc __libc;
 
 size_t __hwcap;
-char *__progname=0, *__progname_full=0;
 
-weak_alias(__progname, program_invocation_short_name);
-weak_alias(__progname_full, program_invocation_name);
+char *program_invocation_short_name=0, *program_invocation_name=0;

--- a/src/internal/libc.h
+++ b/src/internal/libc.h
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <limits.h>
 
+#define __progname program_invocation_short_name
+#define __progname_full program_invocation_name
+
 struct __locale_map;
 
 struct __locale_struct {

--- a/src/internal/libm.h
+++ b/src/internal/libm.h
@@ -252,6 +252,7 @@ hidden long double __tanl(long double, long double, int);
 hidden long double __polevll(long double, const long double *, int);
 hidden long double __p1evll(long double, const long double *, int);
 
+#define __signgam signgam
 extern int __signgam;
 hidden double __lgamma_r(double, int *);
 hidden float __lgammaf_r(float, int *);

--- a/src/internal/stdio_impl.h
+++ b/src/internal/stdio_impl.h
@@ -109,4 +109,6 @@ hidden void __getopt_msg(const char *, const char *, const char *, size_t);
 hidden FILE *__fopen_rb_ca(const char *, FILE *, unsigned char *, size_t);
 hidden int __fclose_ca(FILE *);
 
+#define __optreset optreset
+
 #endif

--- a/src/legacy/err.c
+++ b/src/legacy/err.c
@@ -3,6 +3,8 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
+#define __progname program_invocation_short_name
+
 extern char *__progname;
 
 void vwarn(const char *fmt, va_list ap)

--- a/src/math/signgam.c
+++ b/src/math/signgam.c
@@ -1,6 +1,4 @@
 #include <math.h>
 #include "libm.h"
 
-int __signgam = 0;
-
-weak_alias(__signgam, signgam);
+int signgam = 0;

--- a/src/misc/getopt.c
+++ b/src/misc/getopt.c
@@ -11,7 +11,6 @@ char *optarg;
 int optind=1, opterr=1, optopt, __optpos, __optreset=0;
 
 #define optpos __optpos
-weak_alias(__optreset, optreset);
 
 void __getopt_msg(const char *a, const char *b, const char *c, size_t l)
 {

--- a/src/thread/__timedwait.c
+++ b/src/thread/__timedwait.c
@@ -26,8 +26,7 @@ static int __futex4_cp(volatile void *addr, int op, int val, const struct timesp
 	return __syscall_cp(SYS_futex, addr, op & ~FUTEX_PRIVATE, val, to);
 }
 
-static volatile int dummy = 0;
-weak_alias(dummy, __eintr_valid_flag);
+weak volatile int __eintr_valid_flag = 0;
 
 int __timedwait_cp(volatile int *addr, int val,
 	clockid_t clk, const struct timespec *at, int priv)

--- a/src/time/__tz.c
+++ b/src/time/__tz.c
@@ -13,13 +13,13 @@
 #define realloc undef
 #define free undef
 
+#define __timezone timezone
+#define __daylight daylight
+#define __tzname tzname
+
 long  __timezone = 0;
 int   __daylight = 0;
 char *__tzname[2] = { 0, 0 };
-
-weak_alias(__timezone, timezone);
-weak_alias(__daylight, daylight);
-weak_alias(__tzname, tzname);
 
 static char std_name[TZNAME_MAX+1];
 static char dst_name[TZNAME_MAX+1];


### PR DESCRIPTION
The global variable alias will cause the wrong variable value since two symbols point two different objects. The aliasee will not change when the aliaser changes. I went through all alias variable and found some alias global variables are only used on Linux or used inside of musl libc library. I have modified the musl libc to remove these alias symbol for the repo target.

This patch will solve the clang lit test failures mentioned in https://github.com/SNSystems/musl-prepo/issues/8#issuecomment-880525308.