### PR TITLE
Guard the definition of max_align_t to avoid collision with clang's.

### DIFF
--- a/arch/x86_64/bits/alltypes.h.in
+++ b/arch/x86_64/bits/alltypes.h.in
@@ -17,4 +17,6 @@ TYPEDEF float float_t;
 TYPEDEF double double_t;
 #endif
 
+#ifndef __clang__
 TYPEDEF struct { long long __ll; long double __ld; } max_align_t;
+#endif


### PR DESCRIPTION
Clang's compiler-specific includes provide a definition of max_align_t in usr/lib/clang/11.0.0/include/__stddef_max_align_t.h. This change avoids an error caused by a second definition in musl libc.

The error can be seen in the [hello-rld/cxx](https://github.com/SNSystems/hello-rld/runs/5185314730?check_suite_focus=true) example:
~~~
c++ -target x86_64-pc-linux-musl-repo -fno-exceptions -fno-rtti -O0   -c -o hello.o hello.cpp
In file included from hello.cpp:1:
In file included from /usr/bin/../include/c++/v1/iostream:37:
In file included from /usr/bin/../include/c++/v1/ios:215:
In file included from /usr/bin/../include/c++/v1/__locale:14:
In file included from /usr/bin/../include/c++/v1/string:506:
In file included from /usr/bin/../include/c++/v1/string_view:175:
In file included from /usr/bin/../include/c++/v1/__string:57:
In file included from /usr/bin/../include/c++/v1/algorithm:639:
In file included from /usr/bin/../include/c++/v1/initializer_list:46:
In file included from /usr/bin/../include/c++/v1/cstddef:44:
In file included from /usr/local/musl/include/stddef.h:17:
/usr/local/musl/include/bits/alltypes.h:41:54: error: typedef redefinition with different types ('struct max_align_t' vs 'struct max_align_t')
typedef struct { long long __ll; long double __ld; } max_align_t;

/usr/lib/clang/11.0.0/include/__stddef_max_align_t.h:24:3: note: previous definition is here
} max_align_t;
  ^
1 error generated.
~~~