### PR TITLE
Add EMPTY_LIBS to ALL_TICKET_LIBS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ LINUX_INCLUDES = include/linux/futex.h include/linux/version.h
 
 CRT_TICKET_LIBS = $(addprefix lib/,$(notdir $(CRT_TICKETS)))
 STATIC_TICKET_LIBS = lib/libc_repo.a
-ALL_TICKET_LIBS = $(CRT_TICKET_LIBS) $(STATIC_TICKET_LIBS) $(REPOFILE)
+ALL_TICKET_LIBS = $(CRT_TICKET_LIBS) $(STATIC_TICKET_LIBS) $(EMPTY_LIBS) $(REPOFILE)
 
 all-repo:
 	$(MAKE) $(REPOFILE)


### PR DESCRIPTION
In a traditional build, musl libc ships with a set of empty libraries (specifically, libm.a, librt.a, libpthread.a, libcrypt.a, libutil.a, libxnet.a, libresolv.a, and libdl.a) to satisfy the POSIX requirement that options of the form -lm, -lpthread, etc. be accepted by the compiler. We need to match this behaviour with the repo build.