### PR TITLE
Temporarily eliminate weak-alias of __simple_malloc.

### DIFF
--- a/src/malloc/lite_malloc.c
+++ b/src/malloc/lite_malloc.c
@@ -103,7 +103,9 @@ static void *__simple_malloc(size_t n)
 	return p;
 }
 
-weak_alias(__simple_malloc, __libc_malloc_impl);
+// PH: temporary eliminate use of weak-alias until the repo tools fully support
+// symbol aliasing.
+// weak_alias(__simple_malloc, __libc_malloc_impl);
 
 void *__libc_malloc(size_t n)
 {


### PR DESCRIPTION
The tools appear to have a problem with malloc()/free():
 Start with a simple test file:
~~~C
#include <stdlib.h>
#include <stdio.h>
int main() {
    printf ("Hello\n");
    void * p = malloc (1024);
    printf ("p=%p\n", p);
    free (p);
    printf ("Done\n”);
}
~~~
Compile, link, and run it:
~~~bash
prepo@5c5e749d65a7:~$ cc test.c
prepo@5c5e749d65a7:~$ ./a.out
Hello
p=0x1684000
Segmentation fault (core dumped)
prepo@5c5e749d65a7:~$ 
~~~

Following the control flow inside the musl memory allocation code isn't straightforward (particularly when you don't yet have working debug-info in the toolchain). It involves interaction between a bunch of preprocessor macros and weak symbols and the dreaded alias symbols (for which we have an [open issue](https://github.com/SNSystems/llvm-project-prepo/issues/64)). Adding some traces to the files malloc/lite_malloc.c, malloc/mallocng/malloc.c and malloc/mallocng/ngfree.c to record the functions that are being called, we can start to see what's happening:

~~~bash
prepo@b78d8aa2df1f:~/test$ ./a.out
Hello
lite_malloc/default_malloc
lite_malloc/__simple_malloc
p=0x22b7000
free.c/free
ngfree/free
Segmentation fault (core dumped)
~~~

This shows that we're using the "simple" memory allocator, but the "ng" free functions. We crash in the free() function when it tries to access the metadata that should have been created by the matching allocation function.

I can resolve the problem for the time being by eliminating the macro that creates a weak alias between  __simple_malloc and __libc_malloc_impl (the real memory allocation function).