### PR TITLE
Change the compiler triple to musl-repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ $(NOSSP_TICKETS): CFLAGS_ALL += $(CFLAGS_NOSSP)
 
 $(CRT_TICKETS): CFLAGS_ALL += -DCRT
 
-$(ALL_TICKETS) $(CRT_TICKETS):  CFLAGS_ALL +=  -target x86_64-pc-linux-gnu-repo
+$(ALL_TICKETS) $(CRT_TICKETS):  CFLAGS_ALL +=  -target x86_64-pc-linux-musl-repo
 
 obj/%.t: $(srcdir)/%.s
 	$(AS_CMD)


### PR DESCRIPTION
We are currently building the musl libc code-base using a triple containing "gnu-repo". Since the rest of the system is (likely) built using the, now default, "musl-repo" triple, this needlessly and confusingly adds a GNU-based triple into the mix.

I could have removed the triple altogether since the requested triple is now identical to the repo compiler’s default. I didn’t do this because I felt that it was better to continue making the request for repo output explicitly.